### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/895/256/9/1108952569.geojson
+++ b/data/110/895/256/9/1108952569.geojson
@@ -35,6 +35,9 @@
     "wof:capital_of":85632495,
     "wof:concordances":{},
     "wof:country":"IO",
+    "wof:geom_alt":[
+        "mz"
+    ],
     "wof:geomhash":"fffa541c4fedab49afe744210d0100da",
     "wof:hierarchy":[
         {
@@ -47,7 +50,7 @@
         }
     ],
     "wof:id":1108952569,
-    "wof:lastmodified":1566713765,
+    "wof:lastmodified":1582381171,
     "wof:name":"Camp Justice",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/326/41/85632641.geojson
+++ b/data/856/326/41/85632641.geojson
@@ -464,6 +464,9 @@
         "wof:parent_id"
     ],
     "wof:country":"IO",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2b07ae00e0ec451e264446c39662b31d",
     "wof:hierarchy":[
         {
@@ -473,7 +476,7 @@
         }
     ],
     "wof:id":85632641,
-    "wof:lastmodified":1561766517,
+    "wof:lastmodified":1582381171,
     "wof:name":"Diego Garcia NSF",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.